### PR TITLE
Fix YT Proxy 2.0, and change it to a different clone site. 

### DIFF
--- a/youtube.html
+++ b/youtube.html
@@ -26,7 +26,7 @@
   </nav>
 </header>
     <body id="top">
-      <iframe src='mini.php?https://clipmega.com/' id="gframe" width='100%' height='100%' style='border:none; position:fixed; top: 50' allowTransparency='true'></iframe>
+      <iframe src='mini.php?https://www.clipzui.com/' id="gframe" width='100%' height='100%' style='border:none; position:fixed; top: 50' allowTransparency='true'></iframe>
 
     </body>
   </html>


### PR DESCRIPTION
Reason: Clipmega vomits code when placed in an iframe, and it's quite literally un-usable.